### PR TITLE
Utilizar argp para ler os parâmetros

### DIFF
--- a/Calculadora-primos.c
+++ b/Calculadora-primos.c
@@ -41,7 +41,8 @@ static const char doc[] =
 static const char args_doc[] = "";
 static const struct argp_option options[] = {
     {"live", 'l', 0, 0,
-     "Printar valores em tempo real ao invés de esperar cálculo acabar.", 0}};
+     "Printar valores em tempo real ao invés de esperar cálculo acabar.", 0},
+    {0, 0, 0, 0, 0, 0}};
 
 struct argumentos {
   bool modoLive;

--- a/Calculadora-primos.c
+++ b/Calculadora-primos.c
@@ -35,13 +35,13 @@ SOFTWARE.
 
 const char *argp_program_version = "numeros_primos 1.1";
 const char *argp_program_bug_address = "<moraes.eduardo@proton.me>";
-static char doc[] = " Calculadora de números primos em C, saiba quais números "
-                    "primos existem até certo número.";
-static char args_doc[] = "";
-static struct argp_option options[] = {
+static const char doc[] =
+    " Calculadora de números primos em C, saiba quais números "
+    "primos existem até certo número.";
+static const char args_doc[] = "";
+static const struct argp_option options[] = {
     {"live", 'l', 0, 0,
-     "Printar valores em tempo real ao invés de esperar cálculo acabar.", 0},
-    {0}};
+     "Printar valores em tempo real ao invés de esperar cálculo acabar.", 0}};
 
 struct argumentos {
   bool modoLive;
@@ -61,18 +61,18 @@ static error_t parse_opt(int key, char *arg, struct argp_state *state) {
   return 0;
 }
 
-static struct argp argp = {options, parse_opt, args_doc, doc, 0, 0, 0};
+static const struct argp argp = {options, parse_opt, args_doc, doc, 0, 0, 0};
 
 int main(int argc, char *argv[]) {
   // Alterar locale para suportar UTF-8
   setlocale(LC_ALL, "pt_BR.UTF-8");
 
+  // Inicializar argumentos passados por linha de comando
   struct argumentos argumentos;
-
   argumentos.modoLive = false;
-
   argp_parse(&argp, argc, argv, 0, 0, &argumentos);
 
+  // Pegar o número até onde os números primos serão calculados
   wprintf(L"Vamos calcular todos os números primos até um certo valor, insira "
           L"o número: ");
   unsigned int numero;
@@ -96,7 +96,7 @@ int main(int argc, char *argv[]) {
   //
   else {
     // Alocar array para salvar os números primos
-    bool *numerosPrimos = (bool *)malloc(sizeof(bool) * numero);
+    bool *const numerosPrimos = (bool *)malloc(sizeof(bool) * numero);
     if (!numerosPrimos) {
       wprintf(L"Não foi possível alocar o array de números primos. Saindo.");
       return 1;
@@ -108,7 +108,7 @@ int main(int argc, char *argv[]) {
     }
 
     // Abrir arquivo para salvar os números calculados
-    FILE *fptr = fopen("numeros_primos.txt", "w");
+    FILE *const fptr = fopen("numeros_primos.txt", "w");
     if (!fptr) {
       wprintf(L"Não foi possível abrir o arquivo numeros_primos.txt. Saindo.");
       return 1;
@@ -137,7 +137,7 @@ int main(int argc, char *argv[]) {
 }
 
 // Retorna true caso numero seja primo, false caso não seja
-bool ePrimo(unsigned int numero) {
+bool ePrimo(const unsigned int numero) {
   for (unsigned int i = 2; i < numero; i++) {
     if (numero % i == 0) {
       return false;

--- a/Calculadora-primos.c
+++ b/Calculadora-primos.c
@@ -96,7 +96,7 @@ int main(int argc, char *argv[]) {
   //
   else {
     // Alocar array para salvar os números primos
-    bool *const numerosPrimos = (bool *)malloc(sizeof(bool) * numero);
+    bool *const restrict numerosPrimos = (bool *)malloc(sizeof(bool) * numero);
     if (!numerosPrimos) {
       wprintf(L"Não foi possível alocar o array de números primos. Saindo.");
       return 1;
@@ -108,7 +108,7 @@ int main(int argc, char *argv[]) {
     }
 
     // Abrir arquivo para salvar os números calculados
-    FILE *const fptr = fopen("numeros_primos.txt", "w");
+    FILE *const restrict fptr = fopen("numeros_primos.txt", "w");
     if (!fptr) {
       wprintf(L"Não foi possível abrir o arquivo numeros_primos.txt. Saindo.");
       return 1;

--- a/Calculadora-primos.c
+++ b/Calculadora-primos.c
@@ -40,7 +40,7 @@ static char doc[] = " Calculadora de números primos em C, saiba quais números 
 static char args_doc[] = "";
 static struct argp_option options[] = {
     {"live", 'l', 0, 0,
-     "Printar valores em tempo real ao invés de esperar cálculo acabar."},
+     "Printar valores em tempo real ao invés de esperar cálculo acabar.", 0},
     {0}};
 
 struct argumentos {

--- a/Calculadora-primos.c
+++ b/Calculadora-primos.c
@@ -22,6 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 */
 
+#include <argp.h>
 #include <fcntl.h>
 #include <locale.h>
 #include <stdbool.h>
@@ -32,20 +33,45 @@ SOFTWARE.
 
 #include "Calculadora-primos.h"
 
+const char *argp_program_version = "numeros_primos 1.1";
+const char *argp_program_bug_address = "<moraes.eduardo@proton.me>";
+static char doc[] = " Calculadora de números primos em C, saiba quais números "
+                    "primos existem até certo número.";
+static char args_doc[] = "";
+static struct argp_option options[] = {
+    {"live", 'l', 0, 0,
+     "Printar valores em tempo real ao invés de esperar cálculo acabar."},
+    {0}};
+
+struct argumentos {
+  bool modoLive;
+};
+
+static error_t parse_opt(int key, char *arg, struct argp_state *state) {
+  struct argumentos *argumentos = state->input;
+  switch (key) {
+  case 'l':
+    argumentos->modoLive = true;
+    break;
+  case ARGP_KEY_ARG:
+    return 0;
+  default:
+    return ARGP_ERR_UNKNOWN;
+  }
+  return 0;
+}
+
+static struct argp argp = {options, parse_opt, args_doc, doc, 0, 0, 0};
+
 int main(int argc, char *argv[]) {
   // Alterar locale para suportar UTF-8
   setlocale(LC_ALL, "pt_BR.UTF-8");
 
-  bool modoLive = false;
-  if (argc > 1) {
-    if (strcmp(argv[1], "--live") != 0) {
-      wprintf(L"Argumento inválido. Uso correto:\nNumerosPrimos --live\n");
-      return 1;
-    }
+  struct argumentos argumentos;
 
-    wprintf(L"Iniciado no modo de debug ao vivo!\n");
-    modoLive = true;
-  }
+  argumentos.modoLive = false;
+
+  argp_parse(&argp, argc, argv, 0, 0, &argumentos);
 
   wprintf(L"Vamos calcular todos os números primos até um certo valor, insira "
           L"o número: ");
@@ -56,7 +82,7 @@ int main(int argc, char *argv[]) {
   // MODO LIVE: Os números são printados ao serem calculados, e não são salvos
   // em um arquivo
   //
-  if (modoLive) {
+  if (argumentos.modoLive) {
     for (unsigned int i = 2; i <= numero; i++) {
       if (ePrimo(i)) {
         wprintf(L"O número %u é primo\n", i);

--- a/Calculadora-primos.c
+++ b/Calculadora-primos.c
@@ -38,27 +38,43 @@ const char *argp_program_bug_address = "<moraes.eduardo@proton.me>";
 static const char doc[] =
     " Calculadora de números primos em C, saiba quais números "
     "primos existem até certo número.";
-static const char args_doc[] = "";
+static const char args_doc[] = "[NÚMERO]";
 static const struct argp_option options[] = {
     {"live", 'l', 0, 0,
      "Printar valores em tempo real ao invés de esperar cálculo acabar.", 0},
     {0, 0, 0, 0, 0, 0}};
 
 struct argumentos {
+  char *args[1];
   bool modoLive;
 };
 
 static error_t parse_opt(int key, char *arg, struct argp_state *state) {
   struct argumentos *argumentos = state->input;
+
   switch (key) {
+
   case 'l':
     argumentos->modoLive = true;
     break;
+
   case ARGP_KEY_ARG:
-    return 0;
+    if (state->arg_num >= 1)
+      argp_usage(state);
+
+    argumentos->args[state->arg_num] = arg;
+    break;
+
+  case ARGP_KEY_END:
+    if (state->arg_num < 1)
+      argp_usage(state);
+
+    break;
+
   default:
     return ARGP_ERR_UNKNOWN;
   }
+
   return 0;
 }
 
@@ -70,14 +86,12 @@ int main(int argc, char *argv[]) {
 
   // Inicializar argumentos passados por linha de comando
   struct argumentos argumentos;
+  argumentos.args[0] = argv[0];
   argumentos.modoLive = false;
   argp_parse(&argp, argc, argv, 0, 0, &argumentos);
 
   // Pegar o número até onde os números primos serão calculados
-  wprintf(L"Vamos calcular todos os números primos até um certo valor, insira "
-          L"o número: ");
-  unsigned int numero;
-  scanf("%u", &numero);
+  const unsigned int numero = atoi(argumentos.args[0]);
 
   //
   // MODO LIVE: Os números são printados ao serem calculados, e não são salvos

--- a/README.md
+++ b/README.md
@@ -7,32 +7,20 @@ Uma calculadora que consegue todos os números primos até certo número inserid
 Caso queira apenas testar o programa em sua máquina, você apenas precisar baixar o projeto indo em Releases na interface do GitHub e escolhendo o executável do seu respectivo sistema.
 Como alternativa você pode utilizar o comando `git clone https://github.com/DoodlesEpic/Calculadora-numeros-primos.git` no terminal/cmd para baixar o repositório, e compilar direto da fonte.
 
-### Windows
-
-Para iniciar apenas abra o prompt de comando na pasta em que está o arquivo. Inicie utilizando:
+### Comandos
 
 ```shell
-Calculadora-primos.exe
-```
+Usage: NumerosPrimos [OPTION...] [NÚMERO]
+ Calculadora de números primos em C, saiba quais números primos existem até
+certo número.
 
-ou para iniciar no modo ao vivo:
+  -l, --live                 Printar valores em tempo real ao invés de esperar
+                             cálculo acabar.
+  -?, --help                 Dar a lista de comandos
+      --usage                Mostra como usar o programa
+  -V, --version              Veja a versão do programa
 
-```shell
-Calculadora-primos.exe -l
-```
-
-### Linux
-
-Para iniciar apenas abra o terminal na pasta em que está o arquivo. Inicie utilizando:
-
-```shell
-./Calculadora-primos
-```
-
-ou para iniciar no modo ao vivo:
-
-```shell
-./Calculadora-primos -l
+Reporte bugs para <moraes.eduardo@proton.me>.
 ```
 
 ## Compilar
@@ -42,6 +30,8 @@ Para compilar tenha gcc, clang ou msvc configurado no seu sistema.
 
 ### Debug
 
+A build de debug habilita o address sanitizer para tentar encontrar erros no uso de memória, mas mantém as otimizações -O2 habilitadas.
+
 Para desenvolvimento utilize os comandos:
 
 ```shell
@@ -50,7 +40,9 @@ cd build
 meson compile
 ```
 
-### Prod
+### Release
+
+A build de release desabilita símbolos, address sanitizer e utiliza -O3 como flag de otimização.
 
 Para criar um binário otimizado utilize:
 

--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,5 @@
 project('NumerosPrimos', 'c',
-  version : '0.1',
+  version : '1.1',
   default_options : ['warning_level=3'])
 
 executable('NumerosPrimos',


### PR DESCRIPTION
Parte do GNU libc, utilizado para ler parâmetros de CLI. Inclui automaticamente um --help gerado a partir dos pârametros que o programa pode receber. Essa pull request também refatora algumas partes do código para utilizar const, static e restrict, possivelmente melhorando a performance.
https://www.gnu.org/software/libc/manual/html_node/Argp.html